### PR TITLE
Fixed bug related to hibernate bean initialization with snowflake

### DIFF
--- a/entities/src/main/java/com/iAxis/jumghor/entities/utils/SnowflakeGenerator.java
+++ b/entities/src/main/java/com/iAxis/jumghor/entities/utils/SnowflakeGenerator.java
@@ -5,6 +5,7 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.generator.BeforeExecutionGenerator;
 import org.hibernate.generator.EventType;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import java.util.EnumSet;
 
@@ -12,6 +13,15 @@ import java.util.EnumSet;
  * @author aditya.chakma
  * @since 30 Apr, 2025 4:16 PM
  */
+/*
+ * This ID generator generates id for DB entities
+ * The `@Component` annotation is nedded. Without this, Spring won't inject the
+ * `@Value("${server.id}")`. It generally works without the annotation when all properties are
+ * inside `application.properties` files. But, if we use a separate config-server, we must use
+ * the component for spring injection. Otherwise, this would be a hibernate bean and the value will always be null.
+ * - Aditya
+ * */
+@Component
 public class SnowflakeGenerator implements BeforeExecutionGenerator {
 
     @Value("${server.id}")

--- a/user-service/src/main/java/com/iAxis/jumghor/user/UserServiceApplication.java
+++ b/user-service/src/main/java/com/iAxis/jumghor/user/UserServiceApplication.java
@@ -5,12 +5,11 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @ComponentScan(basePackages = {
         "com.iAxis.jumghor.user",
         "com.iAxis.jumghor.entities.configs",
-        "com.iAxis.jumghor.entities.interceptor"
+        "com.iAxis.jumghor.entities.utils"
 })
 @EntityScan("com.iAxis.jumghor.entities.entity")
 @EnableCaching // todo: disable this annotation

--- a/user-service/src/main/resources/application.properties
+++ b/user-service/src/main/resources/application.properties
@@ -8,7 +8,7 @@ spring.config.import=optional:configserver:http://localhost:8888
 spring.cache.type=simple
 
 ############# for debugging purpose ##################################
- Show SQL queries
+# Show SQL queries
 spring.jpa.show-sql=true
 # Format SQL nicely
 spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
When moving to config-server, the snowflake id generator does not get property 'server.id'. That is beacause the ID generator is a hibernate bean. So we had to add component tag, to make it spring managed. And spring pulls the required value from the config server